### PR TITLE
fixes "cannot reassign to a variable declared with `const`" for EM_RAW_OPTIONS

### DIFF
--- a/js-wrapper.js
+++ b/js-wrapper.js
@@ -1,6 +1,6 @@
 // WARNING: Don't use fancy ES6 in this file, the EMSCRIPTEN minifier does not support it yet.
 
-const EM_RAW_OPTIONS = {
+let EM_RAW_OPTIONS = {
     verbose: 'v',                    //<boolean>  Print verbose messages
     identify: 'i',                   //<boolean>  Identify files without decoding them (use with '-v' to identify files and show metadata)
     toStandardOutput: 'c',           //<boolean>  Write image data to standard output


### PR DESCRIPTION
EM_RAW_OPTIONS is modified later on https://github.com/zfedoran/dcraw.js/blob/v1.0.3/js-wrapper.js#L61 and transpilers will throw an error "cannot reassign to a variable declared with `const`".

Changing this to `let EM_RAW_OPTIONS` will fix this error.